### PR TITLE
change the way to send HOST, PORT to phantom scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Running a script in phantom can soon become performance bottleneck when it comes
 
 ```js
 //every worker gets unique port, get it from a readline
-var port = require("system").stdin.readLine();
+var port = require("system").env['PHANTOM_WORKER_PORT'];
 
 require('webserver').create().listen('127.0.0.1:' + port, function (req, res) {
 	//standard phantomjs script which get input parametrs from request
@@ -53,6 +53,9 @@ phantom.start(function() {
 `host` - ip or hostname where to start listening phantomjs web service, default 127.0.0.1    
 `portLeftBoundary` - don't specify if you just want to take any random free port    
 `portRightBoundary` - don't specify if you just want to take any random free port
+`hostEnvVarName` - customize the name of the environment variable passed to the phantom script that specifies the worker host. defaults to `PHANTOM_WORKER_HOST`
+`portEnvVarName` - customize the name of the environment variable passed to the phantom script that specifies the worker port. defaults to `PHANTOM_WORKER_PORT`
+
 
 
 ##License

--- a/lib/phantomManager.js
+++ b/lib/phantomManager.js
@@ -18,6 +18,8 @@ var PhantomManager = module.exports = function (options) {
     this.options.numberOfWorkers = this.options.numberOfWorkers || numCPUs;
     this.options.timeout = this.options.timeout || 180000;
     this.options.host = this.options.host || "127.0.0.1";
+    this.options.hostEnvVarName = this.options.hostEnvVarName || "PHANTOM_WORKER_HOST"
+    this.options.portEnvVarName = this.options.portEnvVarName || "PHANTOM_WORKER_PORT";
     this._timeouts = [];
     this.tasksQueue = [];
 };
@@ -35,6 +37,8 @@ PhantomManager.prototype.start = function (cb) {
     for (var i = 0; i < self.options.numberOfWorkers; i++) {
         self._phantomInstances.push(new PhantomWorker({
             pathToPhantomScript: self.options.pathToPhantomScript,
+            hostEnvVarName: self.options.hostEnvVarName,
+            portEnvVarName: self.options.portEnvVarName,
             host: self.options.host,
             portLeftBoundary: self.options.portLeftBoundary,
             portRightBoundary: self.options.portRightBoundary

--- a/lib/phantomManager.js
+++ b/lib/phantomManager.js
@@ -34,6 +34,9 @@ PhantomManager.prototype.start = function (cb) {
     });
 
     var started = 0;
+    var workerErrors = [];
+    var couldNotStartWorkersErr;
+
     for (var i = 0; i < self.options.numberOfWorkers; i++) {
         self._phantomInstances.push(new PhantomWorker({
             pathToPhantomScript: self.options.pathToPhantomScript,
@@ -44,12 +47,21 @@ PhantomManager.prototype.start = function (cb) {
             portRightBoundary: self.options.portRightBoundary
         }));
         self._phantomInstances[i].start(function(err) {
-            if (err)
-                cb(err);
+            if (err) {
+                workerErrors.push(err);
+            }
 
             started++;
-            if (started === self.options.numberOfWorkers)
+
+            if (started === self.options.numberOfWorkers) {
+                if (workerErrors.length) {
+                    couldNotStartWorkersErr = new Error("phantom manager could not start all workers..");
+                    couldNotStartWorkersErr.workerErrors = workerErrors;
+                    return cb(couldNotStartWorkersErr);
+                }
+
                 cb(null);
+            }
         });
     }
 };

--- a/lib/phantomWorker.js
+++ b/lib/phantomWorker.js
@@ -102,7 +102,7 @@ PhantomWorker.prototype.checkAlive = function (cb, shot) {
         shot++;
         setTimeout(function() {
             self.checkAlive(cb, shot);
-        }, 50);
+        }, 100);
     });
 };
 

--- a/lib/phantomWorker.js
+++ b/lib/phantomWorker.js
@@ -65,7 +65,15 @@ PhantomWorker.prototype.start = function (cb) {
             self.options.pathToPhantomScript
         ];
 
-        self._childProcess = childProcess.execFile(phantomjs.path, childArgs, function (error, stdout, stderr) {
+        var childOpts = {
+            env: {}
+        };
+
+        childOpts.env[self.options.hostEnvVarName] = self.options.host;
+        childOpts.env[self.options.portEnvVarName] = port;
+
+        //we send host and port as env vars to child process
+        self._childProcess = childProcess.execFile(phantomjs.path, childArgs, childOpts, function (error, stdout, stderr) {
 
         });
 
@@ -73,14 +81,9 @@ PhantomWorker.prototype.start = function (cb) {
 
         process.stdout.setMaxListeners(0);
         process.stderr.setMaxListeners(0);
-        process.stdin.setMaxListeners(0);
 
         self._childProcess.stdout.pipe(process.stdout);
         self._childProcess.stderr.pipe(process.stderr);
-
-        //we send port and host in two lines to make the package back compatible
-        self._childProcess.stdin.write(port + "\n");
-        self._childProcess.stdin.write(self.options.host + "\n");
     });
 };
 

--- a/test/test-script/just-port.js
+++ b/test/test-script/just-port.js
@@ -1,4 +1,4 @@
-var port = require("system").stdin.readLine();
+var port = require("system").env['PHANTOM_WORKER_PORT'];
 
 require('webserver').create().listen('127.0.0.1:' + port, function (req, res) {
     try {

--- a/test/test-script/script.js
+++ b/test/test-script/script.js
@@ -1,5 +1,5 @@
-var port = require("system").stdin.readLine();
-var host = require("system").stdin.readLine();
+var port = require("system").env['PHANTOM_WORKER_PORT'];
+var host = require("system").env['PHANTOM_WORKER_HOST'];
 
 require('webserver').create().listen(host + ':' + port, function (req, res) {
     try {

--- a/test/test-script/slowstart.js
+++ b/test/test-script/slowstart.js
@@ -1,5 +1,5 @@
-var port = require("system").stdin.readLine();
-var host = require("system").stdin.readLine();
+var port = require("system").env['PHANTOM_WORKER_PORT'];
+var host = require("system").env['PHANTOM_WORKER_HOST'];
 
 setTimeout(function() {
     require('webserver').create().listen(host + ':' + port, function (req, res) {

--- a/test/test-script/timeout.js
+++ b/test/test-script/timeout.js
@@ -1,5 +1,5 @@
-var port = require("system").stdin.readLine();
-var host = require("system").stdin.readLine();
+var port = require("system").env['PHANTOM_WORKER_PORT'];
+var host = require("system").env['PHANTOM_WORKER_HOST'];
 
 require('webserver').create().listen(host + ':' + port, function (req, res) {
 


### PR DESCRIPTION
covers #6 
- removed sending the host and port via process.stdin and replaced with env vars in child_process
- add new configuration to customize the name for host/port environment vars passed to phantom scripts
- update tests
- add support for iisnode/azure

FYI: the "should be able to communicate with slowly starting phantom" test always fails for me, even in the current version (without these changes)

os: osx yosemite
node version: 0.10.40

<img width="838" alt="captura de pantalla 2015-09-19 a las 8 54 49 p m" src="https://cloud.githubusercontent.com/assets/4262050/9978889/a3c93388-5f13-11e5-9472-678010ed1e12.png">

we should take a look at that test
