### PR TITLE
ensure callback is called one time when worker process has an error

### DIFF
--- a/lib/phantomManager.js
+++ b/lib/phantomManager.js
@@ -93,6 +93,7 @@ PhantomManager.prototype.execute = function (options, cb) {
 PhantomManager.prototype._executeInWorker = function (worker, options, cb) {
     var self = this;
     var isDone = false;
+    var callbackWasCalled = false;
 
     var timeout = setTimeout(function () {
         self._timeouts.splice(self._timeouts.indexOf(timeout), 1);
@@ -104,10 +105,12 @@ PhantomManager.prototype._executeInWorker = function (worker, options, cb) {
         self.emit("timeout", worker);
 
         worker.recycle(function () {
-            var error = new Error();
-            error.weak = true;
-            error.message = "Timeout";
-            cb(error);
+            if (!callbackWasCalled) {
+                var error = new Error();
+                error.weak = true;
+                error.message = "Timeout";
+                cb(error);
+            }
 
             self.tryFlushQueue();
         });
@@ -116,9 +119,15 @@ PhantomManager.prototype._executeInWorker = function (worker, options, cb) {
     this._timeouts.push(timeout);
 
     worker.execute(options, function (err, result) {
-        if (err)
-            return cb(err);
+        if (isDone)
+            return;
 
+        if (err) {
+            callbackWasCalled = true;
+            return cb(err);
+        }
+
+        callbackWasCalled = true;
         isDone = true;
         self.tryFlushQueue();
         cb(null, result);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "should": "5.0.1"
   },
   "scripts": {
-    "test": "mocha test/test.js"
+    "test": "mocha test/test.js --timeout 4000"
   },
   "main": "index.js",
   "license": "MIT"


### PR DESCRIPTION
this PR ensures when the phantom worker has en error the `_executeInWorker` callback is only called one time.

a race condition existed before between the timeout check and the worker process callback
