### PR TITLE
Allowing phantomPath option so you can specify a custom phantomjs binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ require('webserver').create().listen(host + ':' + port, function (req, res) {
     var title = page.evaluate(function() {
 	    return document.title;
 	});
-	
+
 	//write the result to the response
 	res.statusCode = 200;
     res.write({ title: title });
@@ -56,8 +56,8 @@ phantom.start(function() {
 `portLeftBoundary` - don't specify if you just want to take any random free port<br/>
 `portRightBoundary` - don't specify if you just want to take any random free port<br/>
 `hostEnvVarName` - customize the name of the environment variable passed to the phantom script that specifies the worker host. defaults to `PHANTOM_WORKER_HOST`<br/>
-`portEnvVarName` - customize the name of the environment variable passed to the phantom script that specifies the worker port. defaults to `PHANTOM_WORKER_PORT`
-
+`portEnvVarName` - customize the name of the environment variable passed to the phantom script that specifies the worker port. defaults to `PHANTOM_WORKER_PORT`<br/>
+`phantomPath` - path to the phantomjs library. If not specified, this will use the version of phantom declared in the `optionalDependencies` in `package.json`
 
 
 ##License

--- a/lib/phantomManager.js
+++ b/lib/phantomManager.js
@@ -44,7 +44,8 @@ PhantomManager.prototype.start = function (cb) {
             portEnvVarName: self.options.portEnvVarName,
             host: self.options.host,
             portLeftBoundary: self.options.portLeftBoundary,
-            portRightBoundary: self.options.portRightBoundary
+            portRightBoundary: self.options.portRightBoundary,
+            phantomPath: self.options.phantomPath
         }));
         self._phantomInstances[i].start(function(err) {
             if (err) {

--- a/lib/phantomWorker.js
+++ b/lib/phantomWorker.js
@@ -1,5 +1,4 @@
 var childProcess = require('child_process'),
-    phantomjs = require("phantomjs"),
     cluster = require("cluster"),
     http = require('http'),
     netCluster = require("net-cluster"),
@@ -37,6 +36,10 @@ var PhantomWorker = module.exports = function (options) {
     this.options = options;
     this.isBusy = false;
 
+    if (!this.options.phantomPath) {
+        this.options.phantomPath = require('phantomjs').path;
+    }
+
     if (options.portLeftBoundary && options.portRightBoundary) {
         this.findFreePort = function (cb) {
             findFreePortInRange(options.host, options.portLeftBoundary, options.portRightBoundary, cb);
@@ -73,7 +76,7 @@ PhantomWorker.prototype.start = function (cb) {
         childOpts.env[self.options.portEnvVarName] = port;
 
         //we send host and port as env vars to child process
-        self._childProcess = childProcess.execFile(phantomjs.path, childArgs, childOpts, function (error, stdout, stderr) {
+        self._childProcess = childProcess.execFile(self.options.phantomPath, childArgs, childOpts, function (error, stdout, stderr) {
 
         });
 

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
   },
   "dependencies": {
     "net-cluster": "0.0.2",
-    "phantomjs": "1.9.15",
     "portscanner": "1.0.0",
     "underscore": "1.8.2"
+  },
+  "optionalDependencies": {
+    "phantomjs": "1.9.15"
   },
   "devDependencies": {
     "mocha": "2.1.0",


### PR DESCRIPTION
@pofider 

Thanks for the great library! I tried it out and got PDF rendering from a URL working locally using the phantom-html-to-pdf module. I went to deploy to my AWS EC2 instance and found that the node phantomjs 1.9.15 doesn't properly load on Amazon Linux. To get around this, I implemented the ability to set a path to the phantomjs binary, which seems to be standard in other libraries that rely on phantom, e.g. https://github.com/brenden/node-webshot. I have a related change in phantom-html-to-pdf for which I'll submit another pull request.

Testing:
- Tested without setting the new `phantomPath` option - uses phantomjs 1.9.15, and works on Mac OSX Yosemite 10.10.15.
- Tested adding a dependency to phantomjs2 - 2.0.0 and setting the `phantomPath` to `require('phantomjs2').path` - works on Mac OSX 10.10.15. I noticed features in phantomjs 2.0, such as web fonts to indicate that it was working.
- Tested bundling a custom Amazon Linux binary of phantomjs2 and setting the `phantomPath` to that on my AWS EC2 instances - works on AWS Elastic Beanstalk with 64bit Amazon Linux 2015.03 v2.0.0 running Node.js
